### PR TITLE
Allow for SMSC patching to be configurable

### DIFF
--- a/src/java/com/android/internal/telephony/MessagingResponse.java
+++ b/src/java/com/android/internal/telephony/MessagingResponse.java
@@ -172,14 +172,19 @@ public class MessagingResponse extends IRadioMessagingResponse.Stub {
     public void getSmscAddressResponse(RadioResponseInfo responseInfo, String smsc) {
         if(smsc.contains("\"") || smsc.contains(",")) {
             android.util.Log.e("PHH", "Got weird SMSC: " + smsc);
-            try {
-                String[] a = smsc.split("\"");
-                smsc = a[1];
-            } catch(Throwable t) {
-                android.util.Log.e("PHH", "Failed parsing weird smsc", t);
+            if (android.os.SystemProperties.getBoolean("persist.sys.phh.patch_smsc", true)) {
+                try {
+                    String[] a = smsc.split("\"");
+                    smsc = a[1];
+                } catch(Throwable t) {
+                    android.util.Log.e("PHH", "Failed parsing weird smsc", t);
+                    smsc = "";
+                }
+                android.util.Log.e("PHH", "Patched smsc " + smsc);
+            } else {
+                android.util.Log.e("PHH", "Skipping patching smsc");
                 smsc = "";
             }
-            android.util.Log.e("PHH", "Patched smsc " + smsc);
         }
         RadioResponse.responseString(HAL_SERVICE_MESSAGING, mRil, responseInfo, smsc);
     }

--- a/src/java/com/android/internal/telephony/RadioResponse.java
+++ b/src/java/com/android/internal/telephony/RadioResponse.java
@@ -1239,14 +1239,19 @@ public class RadioResponse extends IRadioResponse.Stub {
     public void getSmscAddressResponse(RadioResponseInfo responseInfo, String smsc) {
         if(smsc.contains("\"") || smsc.contains(",")) {
             android.util.Log.e("PHH", "Got weird SMSC: " + smsc);
-            try {
-                String[] a = smsc.split("\"");
-                smsc = a[1];
-            } catch(Throwable t) {
-                android.util.Log.e("PHH", "Failed parsing weird smsc", t);
+            if (android.os.SystemProperties.getBoolean("persist.sys.phh.patch_smsc", true)) {
+                try {
+                    String[] a = smsc.split("\"");
+                    smsc = a[1];
+                } catch(Throwable t) {
+                    android.util.Log.e("PHH", "Failed parsing weird smsc", t);
+                    smsc = "";
+                }
+                android.util.Log.e("PHH", "Patched smsc " + smsc);
+            } else {
+                android.util.Log.e("PHH", "Skipping patching smsc");
                 smsc = "";
             }
-            android.util.Log.e("PHH", "Patched smsc " + smsc);
         }
         responseString(responseInfo, smsc);
     }


### PR DESCRIPTION
For some reason my carrier (Telemach Slovenia) doesn't require SMSC, but still gives it. Even though SMSC is parsed correctly, my phone (Samsung Galaxy A53 5G) refuses to send messages in case SMSC is not an empty string.

This patch allows for turning SMSC patching off by a persist prop. Should be merged in conjunction with https://github.com/TrebleDroid/treble_app/pull/42.